### PR TITLE
fix: 여러개의 ${} 인자가 text node안에 올때 전부 replace 안되는 문제 해결

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,8 @@
 import html from './jsx';
 
 const hello = 'hello';
+const world = 'world';
+
 const myComponent = html`
   <div
     class="${hello}"
@@ -8,7 +10,7 @@ const myComponent = html`
       alert(hello);
     }}
   >
-    <span>${hello}</span>
+    <span>${hello} ${world}</span>
     <span></span>
   </div>
 `;

--- a/src/jsx.js
+++ b/src/jsx.js
@@ -2,6 +2,7 @@
 exports.__esModule = true;
 var DIRTY_PREFIX = 'dirtyindex:'; // tag names are always all lowercase
 var DIRTY_REGEX = /dirtyindex:(\d+):/;
+var DIRTY_REGEX_G = /dirtyindex:(\d+):/g;
 var html = function (strings) {
   var _a, _b;
   var args = [];
@@ -33,7 +34,7 @@ var html = function (strings) {
   var node;
   while ((node = walker.nextNode())) {
     if (node.nodeType === 3 && ((_a = node.nodeValue) === null || _a === void 0 ? void 0 : _a.includes(DIRTY_PREFIX))) {
-      node.nodeValue = node.nodeValue.replace(DIRTY_REGEX, replaceSubstitution);
+      node.nodeValue = node.nodeValue.replace(DIRTY_REGEX_G, replaceSubstitution);
       continue;
     }
     node = node;

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,5 +1,6 @@
 const DIRTY_PREFIX = 'dirtyindex:'; // tag names are always all lowercase
 const DIRTY_REGEX = /dirtyindex:(\d+):/;
+const DIRTY_REGEX_G = /dirtyindex:(\d+):/g;
 
 const html = (strings: TemplateStringsArray, ...args: any[]): HTMLElement | DocumentFragment | ChildNode => {
   if (!strings[0] && args.length) {
@@ -31,7 +32,7 @@ const html = (strings: TemplateStringsArray, ...args: any[]): HTMLElement | Docu
   let node;
   while ((node = walker.nextNode())) {
     if (node.nodeType === 3 && node.nodeValue?.includes(DIRTY_PREFIX)) {
-      node.nodeValue = node.nodeValue.replace(DIRTY_REGEX, replaceSubstitution);
+      node.nodeValue = node.nodeValue.replace(DIRTY_REGEX_G, replaceSubstitution);
       continue;
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13645032/126901009-85975994-2714-4c05-b1fd-d86aa2b27f90.png)

![image](https://user-images.githubusercontent.com/13645032/126901015-10039013-fea6-40af-8ebb-a91d17ecceea.png)

처음 1개만 replace되고 나머지가 replace 안되는 문제를 해결했습니다.